### PR TITLE
Fixes header end-padding, utf8 yaml, kaitai 0.7 compat

### DIFF
--- a/bytecode/bgi2story
+++ b/bytecode/bgi2story
@@ -407,14 +407,20 @@ end
 
 meta_fn, chars_fn, lang, asset_dir, in_script, out_story = ARGV
 
-cnv = Bgi2StoryConverter.new(
-  in_script,
-  YAML.load(File.read(meta_fn)),
-  YAML.load(File.read(chars_fn)),
-  lang,
-  nil,
-  asset_dir
-)
+cnv = nil
+
+File.open(meta_fn, 'r:bom|utf-8') { |meta_fd|
+  File.open(chars_fn, 'r:bom|utf-8') { |chars_fd|
+    cnv = Bgi2StoryConverter.new(
+      in_script,
+      YAML.load(meta_fd.read()),
+      YAML.load(chars_fd.read()),
+      lang,
+      nil,
+      asset_dir
+    )
+  }
+}
 
 cnv.run
 

--- a/bytecode/bgi2story
+++ b/bytecode/bgi2story
@@ -8,7 +8,11 @@ require 'find'
 
 require_relative 'bgi_decompiler'
 
-require_relative 'converter_common'
+begin
+  require_relative 'converter_common'
+rescue LoadError
+  raise "converter_common.rb is missing, download it from https://github.com/mnakamura1337/engine_bgi/issues/1#issuecomment-233212660 and save it into 'bytecode/'"
+end
 
 class Bgi2StoryConverter
   include ExplicitChars

--- a/bytecode/bgi_compiled_script.ksy
+++ b/bytecode/bgi_compiled_script.ksy
@@ -1,24 +1,29 @@
 meta:
   id: bgi_compiled_script
+  imports:
+    - bgi_bytecode
   application: BGI (Buriko General Interpreter)
   endian: le
 seq:
   - id: magic
-    contents: [
-      "BurikoCompiledScriptVer1.00", 0,
-      0x14, 2, 0, 0,
-      0, 0, 0, 0,
-    ]
+    contents: [ "BurikoCompiledScriptVer1.00", 0 ]
+    doc: VER100 header ft. subs table
+  - id: header_size
+    type: u4
+    doc: not including magic
+  - id: smth_hdr_0020
+    type: u4
+    doc: usually zero
   - id: num_subs
     type: u4
   - id: subs
     type: sub
     repeat: expr
     repeat-expr: num_subs
-  - id: padding
-    size: 14
-  - id: body
+instances:
+  body:
     type: bgi_bytecode
+    pos: header_size + 0x1C
     size-eos: true
 types:
   sub:

--- a/bytecode/bgi_compiled_script.ksy
+++ b/bytecode/bgi_compiled_script.ksy
@@ -11,9 +11,12 @@ seq:
   - id: header_size
     type: u4
     doc: not including magic
-  - id: smth_hdr_0020
+  - id: num_namespaces
     type: u4
-    doc: usually zero
+  - id: namespaces
+    type: namespace
+    repeat: expr
+    repeat-expr: num_namespaces
   - id: num_subs
     type: u4
   - id: subs
@@ -26,6 +29,11 @@ instances:
     pos: header_size + 0x1C
     size-eos: true
 types:
+  namespace:
+    seq:
+      - id: name
+        type: strz
+        encoding: SJIS
   sub:
     seq:
       - id: name

--- a/bytecode/bgi_decompiler.rb
+++ b/bytecode/bgi_decompiler.rb
@@ -43,6 +43,9 @@ class BGIDecompiler
     @sub_by_addr = {}
     begin
       @bs = BgiCompiledScript.from_file(filename)
+      if !@bs.respond_to?(:_debug)
+        raise ".ksy templates must be compiled with --debug (using :start offset info)"
+      end
       @bs._read
 
       # Create sub addr => name mapping
@@ -52,6 +55,7 @@ class BGIDecompiler
 
       @b = @bs.body
     rescue Kaitai::Struct::Stream::UnexpectedDataError => e
+      print e
       # It's not a BgiCompiledScript, try raw bytecode
       @bs = nil
       @b = BgiBytecode.from_file(filename)


### PR DESCRIPTION
- [x] `u32` at file offset 0x1C is used to indicate header size, excluding magic "BurikoCompiledScriptVer1.00\x00". The `.body` struct is now lazy-loaded because it's an `instances` field instead of `seq`.

- [x] Assume input characters.yaml and meta.yaml are UTF-8 encoded (might be specific to Ruby 2.x inclusion of psych vs. 1.9's syck, haven't tested)

- [x] Fail with error message if .ksy templates were not compiled with `--debug`

- [x] Add `imports:` declaration in main ksy  (probably fixes #2)
